### PR TITLE
Tone filter Setting

### DIFF
--- a/alphabit.cpp
+++ b/alphabit.cpp
@@ -708,7 +708,9 @@ void LoopChannel::WriteBuffer(daisy::AudioHandle::InputBuffer in, size_t i)
 	/* FIXME:
 		This method of overdub volume control gradually pushes towards silence.
 		The volume is noticeably too quiet after just a couple passes.
-		This is not a viable alternative and needs to be corrected.
+		This may not be a viable alternative and needs to be corrected.
+		On the other hand, it does create an interesting delay effect.
+		Is there a possible comprosmise
 	*/
 }
 

--- a/alphabit.cpp
+++ b/alphabit.cpp
@@ -1113,6 +1113,14 @@ void Controls()
 			db = 0;
 		}
 
+		// PotMonitor<uint16_t, 3> gkMonitor;
+		// UiEventQueue q;
+		// uint16_t abc = 0;
+		// gkMonitor.Init(q, abc);
+		// if (gkMonitor.IsMoving(0))
+		// {
+
+		// }
 		float freq;
 		if (prevFreqA != freqA)
 		{


### PR DESCRIPTION
Only sets the Tone filter frequency setting when the Knob has been turned, as compared to values taken when a hold has been detected on the main footswitch.